### PR TITLE
Export tracing logic to shared libraries

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,36 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+template: |
+  # What's Changed
+  $CHANGES
+categories:
+  - title: 'Breaking'
+    label: 'type: breaking'
+  - title: 'New'
+    label: 'type: feature'
+  - title: 'Bug Fixes'
+    label: 'type: bug'
+  - title: 'Maintenance'
+    label: 'type: maintenance'
+  - title: 'Documentation'
+    label: 'type: docs'
+  - title: 'Dependency Updates'
+    label: 'type: dependencies'
+
+version-resolver:
+  major:
+    labels:
+      - 'type: breaking'
+  minor:
+    labels:
+      - 'type: feature'
+  patch:
+    labels:
+      - 'type: bug'
+      - 'type: maintenance'
+      - 'type: docs'
+      - 'type: dependencies'
+      - 'type: security'
+
+exclude-labels:
+  - 'skip-changelog'

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,13 @@
+{
+  "automerge": true,
+  "rebaseWhen": "conflicted",
+  "labels": ["type: dependencies"],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "sbt"
+      ],
+      "enabled": false
+    }
+  ]
+}

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,13 @@
+name: Auto approve
+
+on:
+  pull_request_target
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: hmarr/auto-approve-action@v2.1.0
+        if: github.actor == 'scala-steward' || github.actor == 'renovate[bot]'
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,96 @@
+name: CI
+
+env:
+  JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags # JDK_JAVA_OPTIONS is _the_ env. variable to use for modern Java
+  JVM_OPTS: -XX:+PrintCommandLineFlags # for Java 8 only (sadly, it is not modern enough for JDK_JAVA_OPTIONS)
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+on:
+  pull_request:
+  push:
+    branches: ['main']
+  release:
+    types:
+      - published
+
+jobs:
+  lint:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+      - name: Setup Scala and Java
+        uses: olafurpg/setup-scala@v10
+      - name: Cache scala dependencies
+        uses: coursier/cache-action@v6
+      - name: Lint code
+        run: sbt lint
+
+  test:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        java: ['adopt@1.11']
+        scala: ['2.13.8']
+        platform: ['JVM']
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+      - name: Setup Scala and Java
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Cache sbt
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier/cache/v1
+            ~/.cache/coursier/v1
+            ~/AppData/Local/Coursier/Cache/v1
+            ~/Library/Caches/Coursier/v1
+          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+      - name: Build and Test
+        run: sbt ++${{ matrix.scala }}! test
+      - name: Coverage Coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_FLAG_NAME: Scala ${{ matrix.scala }}
+        run: sbt ++${{ matrix.scala }} clean coverage test coverageReport coverageAggregate coveralls
+  ci:
+    runs-on: ubuntu-20.04
+    # needs: [lint, mdoc, test]
+    needs: [lint, test] # TODO: skipping docs (mdoc) due to build github actions issue
+    steps:
+      - name: Aggregate of lint, and all tests
+        run: echo "ci passed"
+
+  # publish:
+  #   runs-on: ubuntu-20.04
+  #   timeout-minutes: 30
+  #   needs: [ci]
+  #   if: github.event_name != 'pull_request'
+  #   steps:
+  #     - name: Checkout current branch
+  #       uses: actions/checkout@v2.3.4
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Setup Scala and Java
+  #       uses: olafurpg/setup-scala@v10
+  #     - name: Cache scala dependencies
+  #       uses: coursier/cache-action@v6
+  #     - name: Release artifacts
+  #       run: sbt ci-release
+  #       env:
+  #         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+  #         PGP_SECRET: ${{ secrets.PGP_SECRET }}
+  #         SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+  #         SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,13 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,21 @@
+name: Website
+
+on:
+  push:
+    branches: [main]
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    if: github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: olafurpg/setup-scala@v10
+      - uses: olafurpg/setup-gpg@v3
+      - run: sbt docs/docusaurusPublishGhpages
+        env:
+          GIT_DEPLOY_KEY: ${{ secrets.GIT_DEPLOY_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+*.class
+*.log
+*.crc
+*.iml
+
+# sbt specific
+.cache
+.history
+.lib/
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+.bsp
+
+# Scala-IDE specific
+.scala_dependencies
+.worksheet
+.idea
+
+# Metals specific
+.metals
+.bloop
+metals.sbt
+
+# Liquibase specific
+schemas/player/liquibase.properties
+
+# VSCode specific
+.vscode
+
+# System specific
+.DS_Store
+*~
+
+__pycache__
+
+# Windows 1909 bug https://github.com/sbt/sbt/issues/5206
+/null/

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,24 @@
+pull_request_rules:
+  - name: assign and label scala-steward's PRs
+    conditions:
+      - author=scala-steward
+    actions:
+      label:
+        add: ["type: dependencies"]
+  - name: label scala-steward's breaking PRs
+    conditions:
+      - author=scala-steward
+      - "body~=(labels: library-update, semver-major)|(labels: sbt-plugin-update, semver-major)"
+    actions:
+      label:
+        add: ["type: breaking"]
+  - name: merge Scala Steward's PRs
+    conditions:
+      - base=master
+      - author=scala-steward
+      - "body~=(labels: library-update, semver-minor)|(labels: library-update, semver-patch)|(labels: sbt-plugin-update, semver-minor)|(labels: sbt-plugin-update, semver-patch)|(labels: scalafix-rule-update)|(labels: test-library-update)"
+      - "status-success=license/cla"
+      - "status-success=ci"
+    actions:
+      merge:
+        method: squash

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,24 @@
+version = "3.4.3"
+assumeStandardLibraryStripMargin = true
+maxColumn = 130
+indentOperator.exclude = "^(~)$"
+indentOperator.topLevelOnly = false
+align.preset = more
+align.tokens = [
+    caseArrow,
+    { code = "{",  owner = "Template" }
+    { code = "}",  owner = "Template" }
+    { code = "%",  owner = applyInfix }
+    { code = "%%", owner =  applyInfix }
+    { code = "%%%",owner =  applyInfix }
+    { code = "⇒",  owner = "Case" }
+    { code = "->", owner = applyInfix }
+    { code = "→",  owner = applyInfix }
+    { code = "<-", owner = "Enumerator.Generator" }
+    { code = "←",  owner = "Enumerator.Generator" }
+]
+align.allowOverflow = true
+rewrite.trailingCommas.style = "keep"
+comments.wrap = no
+docstrings.wrap = no
+runner.dialect = scala213source3

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# trace4cats-zio-extras
+trace4cats-zio-extras
+---------------------
+
+ZIO-specific extensions to the trace4cats library.
+
+# Modules
+
+## core
+
+Defines the core constructs (ZTracer) that are used by the other modules.  This module depends solely on trace4cats + zio.
+
+## sttp
+
+Provides a tracing enriched STTP backend (HTTP client) utilizing the constructs defined in trace4cats-zio-extras-core.
+
+## zhttp
+
+Provides a tracing enriched zio-http server (HTTP server) utilizing the constructs defined in trace4cats-zio-extras-core.
+
+## tests
+
+Defines an externalized test suite, which is required in order to test the components in unison.
+
+Provides helpers to faciliate testing where a `ZTracer` capability is required in the zio environment.
+
+# Usage
+
+Add the following to your `build.sbt`:
+
+```scala
+libraryDependencies += "com.caesars" %% "trace4cats-zio-extras-${MODULE NAME}" % "${VERSION}"
+```

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,105 @@
+import sbt._
+
+val scala2 = "2.13.8"
+
+// val scala3 = "3.1.0"
+
+ThisBuild / organization := "com.caesars"
+ThisBuild / scalaVersion := scala2
+// ThisBuild / crossScalaVersions := List(scala2, scala3)
+ThisBuild / versionScheme := Some("early-semver")
+// usually, this is set by sbt-dynver. For some cases, like an out-of-bound docker image, allow override
+ThisBuild / version ~= (v => sys.env.getOrElse("SBT_VERSION_OVERRIDE", v))
+
+addCommandAlias("lint", "; scalafmtSbt; scalafmtAll")
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "trace4cats-zio-extras",
+  )
+  .aggregate(core, sttp, zhttp, testkit)
+
+lazy val core = mkModule("core")
+  .settings(
+    libraryDependencies ++= List(
+      // TODO: replace Calvin's version with the canonical one once its released
+      "com.github.kaizen-solutions.trace4cats-newrelic" %% "trace4cats-newrelic-http-exporter" % "0.12.2",
+      "org.http4s" %% "http4s-async-http-client" % "0.23.10",
+    )
+  )
+
+lazy val sttp = mkModule("sttp")
+  .settings(
+    libraryDependencies ++= List(
+      "com.softwaremill.sttp.client3" %% "async-http-client-backend-zio1" % "3.5.0",
+      trace4cats("sttp-client3"),
+    )
+  )
+  .dependsOn(core)
+
+lazy val zhttp = mkModule("zhttp")
+  .settings(
+    libraryDependencies ++= List(
+      "com.softwaremill.sttp.tapir" %% "tapir-zio1-http-server" % "0.20.1",
+    )
+  )
+  .dependsOn(core)
+
+lazy val testkit = mkModule("testkit")
+  .dependsOn(core, sttp, zhttp)
+
+def zio(name: String) =
+  "dev.zio" %% name % "1.0.13"
+
+def trace4cats(name: String) =
+  "io.janstenpickle" %% s"trace4cats-$name" % "0.12.0"
+
+def mkModule(id: String) = {
+  val projectName = s"trace4cats-zio-extras-$id"
+  Project(projectName, file("modules") / id)
+    .settings(
+      name := projectName,
+      Compile / console / scalacOptions ~= (_.filterNot(Set("-Xfatal-warnings"))),
+      Test / fork := true,
+      Test / testForkedParallel := true,
+      Test / parallelExecution := true,
+      testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+      scalacOptions ++= {
+        val opts = CrossVersion.partialVersion(scalaVersion.value) match {
+          case Some((2, _)) =>
+            List(
+              "-language:postfixOps",
+              "-Wconf:cat=w-flag-dead-code:silent",
+              "-Wunused:_,-implicits",
+              // helps with unused implicits warning
+              "-Ywarn-macros:after",
+              "-Xsource:3",
+              "-P:kind-projector:underscore-placeholders",
+              "-Xsource:3"
+            )
+          case _ =>
+            List("-Ykind-projector:underscores")
+        }
+        "-language:postfixOps" :: opts
+      },
+      resolvers ++= Seq("jitpack" at "https://jitpack.io"),
+      libraryDependencies ++= Seq(
+        trace4cats("base-zio"),
+        trace4cats("inject-zio"),
+        "dev.zio" %% "zio-interop-cats" % "3.2.9.1",
+        zio("zio"),
+        zio("zio-test") % Test,
+        zio("zio-test-sbt") % Test,
+        "io.github.kitlangton" %% "zio-magic" % "0.3.11" % Test,
+      ),
+      libraryDependencies ++= {
+        if (CrossVersion.partialVersion(scalaVersion.value).exists(_._1 == 2))
+          List(
+            compilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full),
+            compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
+          )
+        else
+          Nil
+      }
+    )
+}

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+install:
+  - sbt -v +publishM2
+

--- a/modules/core/src/main/scala/com/caesars/tracing/TracingUtils.scala
+++ b/modules/core/src/main/scala/com/caesars/tracing/TracingUtils.scala
@@ -1,0 +1,55 @@
+package com.caesars.tracing
+
+import io.janstenpickle.trace4cats.inject.EntryPoint
+import io.janstenpickle.trace4cats.kernel.{SpanCompleter, SpanSampler}
+import io.janstenpickle.trace4cats.model.TraceProcess
+import io.janstenpickle.trace4cats.newrelic.{Endpoint, NewRelicSpanCompleter}
+import org.asynchttpclient.DefaultAsyncHttpClientConfig
+import org.http4s.asynchttpclient.client.AsyncHttpClient
+import org.http4s.client.Client
+import org.http4s.client.middleware.Logger
+import zio.*
+import zio.interop.catz.*
+import zio.interop.catz.implicits.rts
+
+object TracingUtils {
+  private val sampler: ULayer[Has[SpanSampler[Task]]] = ZLayer.succeed(SpanSampler.always[Task])
+  private val client: ULayer[Has[Client[Task]]] =
+    // Blaze client does not support proxy, se we use Async client implementation (same underlying impl as Sttp)
+    AsyncHttpClient
+      .resource[Task] {
+        // Using the defailt configs disrupts setting the proxy, so...
+        // use the AHC defaults https://github.com/AsyncHttpClient/async-http-client/blob/master/client/src/main/resources/org/asynchttpclient/config/ahc-default.properties
+        // these are overridable using system properties if need be
+        new DefaultAsyncHttpClientConfig.Builder().setUseProxySelector(true).build()
+      }
+      .map(Logger(logHeaders = true, logBody = false, logAction = Some(s => Task(org.log4s.getLogger.debug(s)))))
+      .toManagedZIO
+      .orDie
+      .toLayer
+
+  final case class NewrelicCompleterConfig(traceProcess: TraceProcess, apiKey: String, endpoint: Endpoint)
+
+  val newRelicCompleter: URLayer[Has[NewrelicCompleterConfig], Has[SpanCompleter[Task]]] =
+    ZLayer.service[NewrelicCompleterConfig] ++ client >>>
+      ZManaged
+        .services[Client[Task], NewrelicCompleterConfig]
+        .flatMap { case (client, config) =>
+          NewRelicSpanCompleter[Task](
+            client = client,
+            process = config.traceProcess,
+            apiKey = config.apiKey,
+            endpoint = config.endpoint
+          ).toManagedZIO
+        }
+        .orDie
+        .toLayer
+
+  val entryPointLayer: URLayer[Has[SpanSampler[Task]] & Has[SpanCompleter[Task]], Has[EntryPoint[Task]]] =
+    (for {
+      (sampler, completer) <- ZIO.services[SpanSampler[Task], SpanCompleter[Task]]
+    } yield EntryPoint[Task](sampler, completer)).toLayer
+
+  val newRelicEntryPoint: URLayer[Has[NewrelicCompleterConfig], Has[EntryPoint[Task]]] =
+    sampler ++ (ZLayer.service[NewrelicCompleterConfig] >>> newRelicCompleter) >>> entryPointLayer
+}

--- a/modules/core/src/main/scala/com/caesars/tracing/ZTracer.scala
+++ b/modules/core/src/main/scala/com/caesars/tracing/ZTracer.scala
@@ -1,0 +1,85 @@
+package com.caesars.tracing
+
+import cats.data.NonEmptyList
+import io.janstenpickle.trace4cats.inject.EntryPoint
+import io.janstenpickle.trace4cats.model.*
+import io.janstenpickle.trace4cats.{ErrorHandler, Span}
+import zio.*
+import zio.interop.catz.*
+
+//TODO: find away to remove the option
+//We have the following problem:
+//In application code, we should be blissfully unaware of what spans have been created before and where we are in the structure
+//Specifically, you should not need to know whether you are creating a root span or a child span
+//Also, applications may have more than one root span
+
+//What we would like, is a ZTracer that always has a span, and can perform `context`, `setStatus`, `putAll` and `span` safely
+final case class ZTracer private (
+    private val currentSpan: FiberRef[Option[ZSpan]],
+    private val entryPoint: EntryPoint[Task]
+) { self =>
+  def context: UIO[SpanContext] =
+    currentSpan.get.map(_.fold(SpanContext.invalid)(_.context))
+
+  def span[R, E, A](
+      name: String,
+      kind: SpanKind = SpanKind.Internal,
+      errorHandler: ErrorHandler = ErrorHandler.empty
+  )(
+      f: ZSpan => ZIO[R, E, A]
+  ): ZIO[R, E, A] =
+    currentSpan.get.toManaged_
+      .flatMap {
+        case None =>
+          entryPoint
+            .root(name, kind, errorHandler)
+            .map(ZSpan(_))
+            .toManagedZIO
+            .orElse(ZSpan.noop)
+        case Some(span) =>
+          span.child(name, kind, errorHandler)
+      }
+      .use(child => currentSpan.locally(Some(child))(f(child)))
+
+  def fromHeaders[R, E, A](
+      headers: TraceHeaders,
+      kind: SpanKind = SpanKind.Internal,
+      name: String
+  )(f: ZSpan => ZIO[R, E, A]): ZIO[R, E, A] =
+    entryPoint
+      .continueOrElseRoot(name, kind, headers)
+      .toManagedZIO
+      .map(ZSpan(_))
+      .orElse(ZSpan.noop)
+      .use(child => currentSpan.locally(Some(child))(f(child)))
+}
+
+object ZTracer {
+  val layer: URLayer[Has[EntryPoint[Task]], Has[ZTracer]] =
+    (for {
+      entryPoint <- ZIO.service[EntryPoint[Task]]
+      fiberRef   <- FiberRef.make(Option.empty[ZSpan])
+    } yield new ZTracer(
+      currentSpan = fiberRef,
+      entryPoint = entryPoint
+    )).toLayer
+}
+
+final class ZSpan(span: Span[Task]) {
+  def context: SpanContext = span.context
+  def put(key: String, value: AttributeValue): UIO[Unit] = span.put(key, value).ignore
+  def putAll(fields: (String, AttributeValue)*): UIO[Unit] = span.putAll(fields*).ignore
+  def putAll(fields: Map[String, AttributeValue]): UIO[Unit] = span.putAll(fields).ignore
+  def setStatus(spanStatus: SpanStatus): UIO[Unit] = span.setStatus(spanStatus).ignore
+  def addLink(link: Link): UIO[Unit] = span.addLink(link).ignore
+  def addLinks(links: NonEmptyList[Link]): UIO[Unit] = span.addLinks(links).ignore
+  def child(name: String, kind: SpanKind): UManaged[ZSpan] =
+    span.child(name, kind).map(ZSpan(_)).toManagedZIO.orElse(ZSpan.noop)
+  def child(name: String, kind: SpanKind, errorHandler: ErrorHandler): UManaged[ZSpan] =
+    span.child(name, kind, errorHandler).map(ZSpan(_)).toManagedZIO.orElse(ZSpan.noop)
+}
+
+object ZSpan {
+  def apply(span: Span[Task]): ZSpan = new ZSpan(span)
+  val noop: UManaged[ZSpan] = Span.noop[Task].toManagedZIO.map(ZSpan(_)).orDie
+}

--- a/modules/sttp/src/main/scala/com/caesars/tracing/TracedBackend.scala
+++ b/modules/sttp/src/main/scala/com/caesars/tracing/TracedBackend.scala
@@ -1,0 +1,58 @@
+package com.caesars.tracing
+
+import io.janstenpickle.trace4cats.{ErrorHandler, ToHeaders}
+import io.janstenpickle.trace4cats.model.{SampleDecision, SpanKind}
+import io.janstenpickle.trace4cats.sttp.client3.{SttpRequest, SttpSpanNamer}
+import io.janstenpickle.trace4cats.sttp.common.{SttpHeaders, SttpStatusMapping}
+import sttp.capabilities.Effect
+import sttp.client3.impl.zio.RIOMonadAsyncError
+import sttp.client3.*
+import sttp.monad.MonadError
+import zio.*
+
+object TracedBackend {
+  final case class TracedBackendConfig(
+      spanNamer: SttpSpanNamer = SttpSpanNamer.methodWithPath,
+      toHeaders: ToHeaders = ToHeaders.all
+  )
+
+  def apply(
+      delegate: SttpBackend[Task, ZioSttpCapabilities],
+      tracer: ZTracer,
+      config: TracedBackendConfig = TracedBackendConfig()
+  ): SttpBackend[Task, ZioSttpCapabilities] =
+    new SttpBackend[Task, ZioSttpCapabilities] {
+      override def send[T, R >: ZioSttpCapabilities & Effect[Task]](request: Request[T, R]): Task[Response[T]] = {
+        def createSpannedResponse(span: ZSpan, request: Request[T, R]): Task[Response[T]] = {
+          val headers = config.toHeaders.fromContext(span.context)
+          val reqWithTraceHeaders = request.headers(SttpHeaders.converter.to(headers).headers*)
+          for {
+            _ <- span
+              .putAll(SttpRequest.toAttributes(request).toList*)
+              .unless(span.context.traceFlags.sampled == SampleDecision.Drop)
+            response <- delegate.send(reqWithTraceHeaders)
+            _        <- span.setStatus(SttpStatusMapping.statusToSpanStatus(response.statusText, response.code))
+          } yield response
+        }
+
+        def createErrorHandler: ErrorHandler = { case HttpError(body, statusCode) =>
+          SttpStatusMapping.statusToSpanStatus(body.toString, statusCode)
+        }
+
+        tracer.span(
+          config.spanNamer(request),
+          SpanKind.Client,
+          createErrorHandler
+        )(createSpannedResponse(_, request))
+      }
+
+      override def close(): Task[Unit] = delegate.close()
+
+      override def responseMonad: MonadError[Task] = new RIOMonadAsyncError[Any]
+    }
+
+  val layer: URLayer[
+    Has[ZTracer] & Has[SttpBackend[Task, ZioSttpCapabilities]] & Has[TracedBackendConfig],
+    Has[SttpBackend[Task, ZioSttpCapabilities]]
+  ] = (TracedBackend(_, _, _)).toLayer
+}

--- a/modules/sttp/src/main/scala/com/caesars/tracing/package.scala
+++ b/modules/sttp/src/main/scala/com/caesars/tracing/package.scala
@@ -1,0 +1,8 @@
+package com.caesars
+
+import sttp.capabilities.WebSockets
+import sttp.capabilities.zio.ZioStreams
+
+package object tracing {
+  type ZioSttpCapabilities = ZioStreams & WebSockets
+}

--- a/modules/testkit/src/main/scala/com/caesars/tracing/InMemoryTracer.scala
+++ b/modules/testkit/src/main/scala/com/caesars/tracing/InMemoryTracer.scala
@@ -1,0 +1,9 @@
+package com.caesars.tracing
+
+import io.janstenpickle.trace4cats.inject.EntryPoint
+import zio.interop.catz.*
+import zio.{Task, ZLayer}
+
+object InMemoryTracer {
+  val make = ZLayer.succeed(EntryPoint.noop[Task]) >>> ZTracer.layer
+}

--- a/modules/testkit/src/test/scala/com/caesars/tracing/TracingTestUtils.scala
+++ b/modules/testkit/src/test/scala/com/caesars/tracing/TracingTestUtils.scala
@@ -1,0 +1,187 @@
+package com.caesars.tracing
+
+import cats.effect.kernel.Ref
+import io.janstenpickle.trace4cats.`export`.RefSpanCompleter
+import io.janstenpickle.trace4cats.inject.EntryPoint
+import io.janstenpickle.trace4cats.kernel.{SpanCompleter, SpanSampler}
+import io.janstenpickle.trace4cats.model.{CompletedSpan, SpanKind, TraceHeaders, TraceProcess}
+import sttp.client3
+import sttp.client3.impl.zio.RIOMonadAsyncError
+import sttp.client3.{Identity, RequestT, SttpBackend, UriContext, basicRequest, Response as SttpResponse}
+import sttp.client3.testing.SttpBackendStub
+import sttp.model.RequestMetadata
+import zhttp.http.*
+import zhttp.service.Server
+import zio.interop.catz.*
+import zio.interop.catz.implicits.rts
+import zio.{Has, Task, UIO, ULayer, URLayer, ZIO, ZLayer}
+
+import scala.collection.immutable.Queue
+
+object TracingTestUtils {
+
+  val refSpanCompleter: ULayer[Has[RefSpanCompleter[Task]]] =
+    RefSpanCompleter[Task]("my-service").toLayer.orDie
+
+  def entryPointRef: ZLayer[Has[RefSpanCompleter[Task]], Nothing, Has[EntryPoint[Task]]] =
+    ZIO.service[RefSpanCompleter[Task]].map(EntryPoint(sampler, _)).toLayer
+
+  val sampler: SpanSampler[Task] = SpanSampler.always[Task]
+
+  val ref: ULayer[Has[Ref[Task, Queue[CompletedSpan]]]] =
+    cats.effect.Ref.of[Task, Queue[CompletedSpan]](Queue.empty).toLayer.orDie
+
+  val completer: URLayer[Has[Ref[Task, Queue[CompletedSpan]]], Has[SpanCompleter[Task]]] = ZIO
+    .service[cats.effect.Ref[Task, Queue[CompletedSpan]]]
+    .map(new RefSpanCompleter[Task](TraceProcess("ZTracerImplementationSpec"), _))
+    .toLayer
+
+  val successBackend: SttpBackendStub[Task, Nothing] =
+    SttpBackendStub(new RIOMonadAsyncError[Any]).whenRequestMatchesPartial { req =>
+      SttpResponse.ok(()).copy(request = RequestMetadata(req.method, req.uri, req.headers))
+    }
+
+  val failBackend: SttpBackendStub[Task, Nothing] =
+    SttpBackendStub(new RIOMonadAsyncError[Any]).whenAnyRequest.thenRespondServerError()
+}
+
+object ZTracerSpecUtils {
+  def spanSpec(
+      name: String = "root",
+      kind: SpanKind = SpanKind.Internal
+  )(
+      f: ZSpan => UIO[Unit],
+      s: RefSpanCompleter[Task] => Task[CompletedSpan]
+  ): ZIO[Has[ZTracer] with Has[RefSpanCompleter[Task]], Throwable, CompletedSpan] =
+    for {
+      (tracer, ctr) <- ZIO.services[ZTracer, RefSpanCompleter[Task]]
+      _             <- tracer.span(name, kind)(f(_))
+      span          <- s(ctr)
+    } yield span
+
+  def spanFromHeadersSpec(
+      s: RefSpanCompleter[Task] => Task[CompletedSpan]
+  ): ZIO[Has[ZTracer] & Has[RefSpanCompleter[Task]], Throwable, CompletedSpan] =
+    for {
+      (tracer, ctr) <- ZIO.services[ZTracer, RefSpanCompleter[Task]]
+      _             <- tracer.fromHeaders(TraceHeaders.empty, SpanKind.Internal, "mySpan")(_ => ZIO.unit)
+      span          <- s(ctr)
+    } yield span
+}
+
+object ZTracerImplementationSpecUtils {
+  def implementationSpec(
+      be: SttpBackend[Task, ZioSttpCapabilities],
+      requestMap: RequestT[Identity, Either[String, String], Any] => RequestT[Identity, Either[String, String], Any] = identity
+  ) = {
+    val req: client3.Request[Either[String, String], Any] = basicRequest.get(uri"http://www.google.com/")
+
+    for {
+      tracer <- ZIO.service[ZTracer]
+      sbe = TracedBackend(be, tracer)
+      res   <- requestMap(req).send(sbe)
+      ref   <- ZIO.service[cats.effect.Ref[Task, Queue[CompletedSpan]]]
+      spans <- ref.get
+      span = spans.head
+    } yield (spans, span, res)
+  }
+
+  val singleAppImplementationSpec = {
+    val app =
+      Http.collectZIO[Request] { case Method.GET -> !! / "foo" =>
+        ZIO.succeed(Response.ok)
+      }
+
+    for {
+      tracedApp1 <- TracedHttp.layer()(app)
+      _          <- tracedApp1(Request(Method.GET, URL(Path("/foo"))))
+      ref        <- ZIO.service[cats.effect.Ref[Task, Queue[CompletedSpan]]]
+      spans      <- ref.get
+      span = spans.head
+    } yield (spans, span)
+  }
+
+  val failingSingleAppImplementationSpec = {
+    val app =
+      Http.collectZIO[Request] { case Method.GET -> !! / "foo" =>
+        ZIO.fail(new Throwable("boom"))
+      }
+
+    val recover: Throwable => HttpApp[Any, Nothing] =
+      e => Http.error(e.getMessage)
+
+    for {
+      tracedApp <- TracedHttp.layer()(app.catchAll(recover))
+      _         <- tracedApp(Request(Method.GET, URL(Path("/foo")))).either
+      ref       <- ZIO.service[cats.effect.Ref[Task, Queue[CompletedSpan]]]
+      spans     <- ref.get
+      span = spans.head
+    } yield span
+  }
+
+  val notFoundSingleAppImplementationSpec = {
+    val app =
+      Http.collectZIO[Request] { case Method.GET -> !! / "bar" =>
+        ZIO.fail(new Throwable("boom"))
+      }
+
+    for {
+      tracedApp <- TracedHttp.layer()(app ++ Http.notFound)
+      _         <- tracedApp(Request(Method.GET, URL(Path("/foo")))).either
+      ref       <- ZIO.service[cats.effect.Ref[Task, Queue[CompletedSpan]]]
+      spans     <- ref.get
+      span = spans.head
+    } yield span
+  }
+
+  val singleTapirAppSpec = {
+    val tapirApp = {
+      import sttp.tapir.server.ziohttp.ZioHttpInterpreter
+      import sttp.tapir.ztapir.*
+
+      val ep = endpoint.get
+        .in("foo")
+        .errorOut(stringBody)
+        .zServerLogic(_ => ZIO.fail("boom"))
+
+      ZioHttpInterpreter().toHttp(ep)
+    }
+
+    for {
+      tracedApp <- TracedHttp.layer()(tapirApp)
+      _         <- tracedApp(Request(Method.GET, URL(Path("/foo")))).either
+      ref       <- ZIO.service[cats.effect.Ref[Task, Queue[CompletedSpan]]]
+      spans     <- ref.get
+      span = spans.head
+    } yield span
+  }
+
+  val multiAppImplementationSpec = {
+    val app1 =
+      Http.collectZIO[Request] { case Method.GET -> !! / "foo" =>
+        ZIO.service[SttpBackend[Task, ZioSttpCapabilities]].flatMap { client =>
+          basicRequest
+            .get(uri"http://localhost:9090/bar")
+            .send(client)
+            .as(Response.ok)
+        }
+      }
+
+    val app2 =
+      Http.collect[Request] { case Method.GET -> !! / "bar" =>
+        Response.ok
+      }
+
+    for {
+      tracedApp <- TracedHttp.layer()(app1 ++ app2)
+      _ <- (Server.app(tracedApp) ++ Server.port(9090)).make.use(_ =>
+        ZIO
+          .service[SttpBackend[Task, ZioSttpCapabilities]]
+          .flatMap(backend => basicRequest.get(uri"http://localhost:9090/foo").send(backend))
+      )
+      ref    <- ZIO.service[cats.effect.Ref[Task, Queue[CompletedSpan]]]
+      result <- ref.get
+      root = result.last
+    } yield (result, root)
+  }
+}

--- a/modules/testkit/src/test/scala/com/caesars/tracing/ZTracerInstrumentationSpec.scala
+++ b/modules/testkit/src/test/scala/com/caesars/tracing/ZTracerInstrumentationSpec.scala
@@ -1,0 +1,129 @@
+package com.caesars.tracing
+
+import com.caesars.tracing.TracedBackend.TracedBackendConfig
+import com.caesars.tracing.TracingUtils.entryPointLayer
+import com.caesars.tracing.testing.*
+import io.janstenpickle.trace4cats.ToHeaders
+import io.janstenpickle.trace4cats.model.{SpanKind, SpanStatus}
+import org.typelevel.ci.CIString
+import sttp.client3.asynchttpclient.zio.AsyncHttpClientZioBackend
+import sttp.model.Header
+import zhttp.service.EventLoopGroup
+import zhttp.service.server.ServerChannelFactory
+import zio.*
+import zio.magic.*
+import zio.test.*
+
+object ZTracerInstrumentationSpec extends DefaultRunnableSpec {
+  import TracingTestUtils.*
+  import ZTracerImplementationSpecUtils.*
+
+  override def spec = suite("Ztracer Instrumentation for zio-http and Sttp Client")(
+    suite("Sttp client instrumentation")(
+      testM("creates a span for a successful request") {
+        implementationSpec(successBackend).map { case (spans, span, res) =>
+          assertTrue(
+            res.code.isSuccess,
+            spans.length == 1,
+            span.context.parent.isEmpty,
+            span.name == "GET ",
+            span.attributes.get("remote.service.hostname").map(_.value.value).contains("www.google.com")
+          )
+        }
+      },
+      testM("forwards correlation headers") {
+        implementationSpec(successBackend).map { case (spans, _, res) =>
+          val traceHeaders = ToHeaders.standard.fromContext(spans.last.context).values
+          assertTrue(
+            traceHeaders.toSet.subsetOf(
+              res.request.headers.map(h => CIString(h.name) -> h.value).toSet
+            )
+          )
+        }
+      },
+      testM("preserves original headers") {
+        implementationSpec(successBackend, _.header("foo", "bar")).map { case (_, _, res) =>
+          assertTrue(
+            res.request.headers.contains(Header("foo", "bar"))
+          )
+        }
+      },
+      testM("creates a span for a failed request") {
+        implementationSpec(failBackend).map { case (spans, span, res) =>
+          assertTrue(
+            !res.code.isSuccess,
+            spans.length == 1,
+            span.context.parent.isEmpty,
+            span.name == "GET ",
+            span.attributes.get("remote.service.hostname").map(_.value.value).contains("www.google.com")
+          )
+        }
+      }
+    ),
+    suite("zio-http server instrumentation")(
+      testM("creates a span for a successful request") {
+        singleAppImplementationSpec.map { case (spans, span) =>
+          assertTrue(
+            spans.length == 1,
+            span.kind == SpanKind.Server,
+            span.context.parent.isEmpty,
+            span.name == "GET /foo"
+          )
+        }
+      },
+      testM("creates a span for a failed request") {
+        failingSingleAppImplementationSpec.map { span =>
+          assertTrue(
+            span.status == SpanStatus.Internal("Internal Server Error"),
+            span.attributes.contains("status.code", 500)
+          )
+        }
+      },
+      testM("creates a span for an unmatched request") {
+        notFoundSingleAppImplementationSpec.map { span =>
+          assertTrue(
+            span.status == SpanStatus.NotFound,
+            span.attributes.contains("status.code", 404)
+          )
+        }
+      },
+      testM("creates a span for an http app generated from Tapir") {
+        singleTapirAppSpec.map { span =>
+          assertTrue(
+            span.status == SpanStatus.Internal("Bad Request"),
+            span.attributes.contains("status.code", 400)
+          )
+        }
+      }
+    ),
+    testM("A client -> server -> client -> server interaction is recorded correctly") {
+      multiAppImplementationSpec.map { case (result, root) =>
+        assertTrue(
+          // only one root
+          result.count(_.context.parent.isEmpty) == 1,
+          result.map(span => (span.name, span.kind)).toList ==
+            List(
+              "GET /bar" -> SpanKind.Server,
+              "GET bar" -> SpanKind.Client,
+              "GET /foo" -> SpanKind.Server,
+              "GET foo" -> SpanKind.Client
+            ),
+          root.name == "GET foo",
+          root.context.parent.isEmpty,
+          result.forall(_.status.isOk)
+        )
+      }
+    }
+  ).inject(
+    ZLayer.succeed(sampler),
+    ref,
+    completer,
+    entryPointLayer,
+    ZTracer.layer,
+    ZLayer.succeed(TracedBackendConfig()),
+    ZLayer.identity[Has[ZTracer]] ++ AsyncHttpClientZioBackend.layer().orDie ++ ZLayer
+      .identity[Has[TracedBackendConfig]] >>> TracedBackend.layer,
+    EventLoopGroup.auto(),
+    ServerChannelFactory.auto
+  )
+}

--- a/modules/testkit/src/test/scala/com/caesars/tracing/ZTracerSpec.scala
+++ b/modules/testkit/src/test/scala/com/caesars/tracing/ZTracerSpec.scala
@@ -1,0 +1,84 @@
+package com.caesars.tracing
+
+import com.caesars.tracing.testing.*
+import io.janstenpickle.trace4cats.`export`.RefSpanCompleter
+import io.janstenpickle.trace4cats.model.AttributeValue.StringValue
+import io.janstenpickle.trace4cats.model.{SpanContext, SpanKind, SpanStatus}
+import zio.*
+import zio.magic.*
+import zio.test.*
+import zio.test.environment.TestEnvironment
+
+object ZTracerSpec extends DefaultRunnableSpec {
+  import TracingTestUtils.*
+  import ZTracerSpecUtils.*
+
+  override def spec: ZSpec[TestEnvironment, Any] = {
+    suite("ZTracer")(
+      testM("starts out with no span") {
+        ZIO.service[ZTracer].flatMap(_.context).map(context => assertTrue(context == SpanContext.invalid))
+      },
+      testM("can create a span and add attributes to it") {
+        spanSpec()(span => span.putAll(("fieldName", StringValue("fieldValue"))), completer => completer.get.map(_.head)).map {
+          cs =>
+            assertTrue(
+              cs.attributes.contains("fieldName", "fieldValue"),
+              cs.name == "root"
+            )
+        }
+      },
+      testM("can create a span and set its status") {
+        spanSpec()(_.setStatus(SpanStatus.Aborted), completer => completer.get.map(_.head)).map { cs =>
+          assertTrue(
+            cs.status == SpanStatus.Aborted
+          )
+        }
+      },
+      testM("can continue a span from empty headers") {
+        spanFromHeadersSpec(_.get.map(_.head)).map { cs =>
+          assertTrue(
+            cs.isRoot,
+            cs.name == "mySpan"
+          )
+        }
+      },
+      testM("can simultaneously create multiple roots") {
+        def app(name: String) = for {
+          tracer <- ZIO.service[ZTracer]
+          _      <- tracer.span(name)(_.putAll("a" -> StringValue(name)))
+        } yield ()
+
+        val appNames = 1 to 20 map (i => s"app $i") toSet
+
+        for {
+          _         <- ZIO.foreachPar_(appNames)(app)
+          completer <- ZIO.service[RefSpanCompleter[Task]]
+          result    <- completer.get
+        } yield assertTrue(
+          result.length == 20,
+          result.forall(span => span.isRoot),
+          result.flatMap(span => evalAttributes(span.attributes).get("a")).toSet ==
+            appNames.asInstanceOf[Set[Any]]
+        )
+      },
+      testM("can create nested spans") {
+        for {
+          tracer    <- ZIO.service[ZTracer]
+          _         <- tracer.span("parent")(_.child("child", SpanKind.Internal).use(_ => ZIO.unit))
+          completer <- ZIO.service[RefSpanCompleter[Task]]
+          result    <- completer.get
+          parent = result.find(s => s.name == "parent").getOrElse(throw new Exception("boom"))
+          child = result.find(s => s.name == "child").getOrElse(throw new Exception("boom"))
+        } yield assertTrue(
+          result.length == 2,
+          result.map(s => s.name).toSet == Set("parent", "child"),
+          child.context.parent.map(_.spanId).contains(parent.context.spanId)
+        )
+      }
+    ).inject(
+      refSpanCompleter,
+      entryPointRef,
+      ZTracer.layer
+    )
+  }
+}

--- a/modules/testkit/src/test/scala/com/caesars/tracing/testing/package.scala
+++ b/modules/testkit/src/test/scala/com/caesars/tracing/testing/package.scala
@@ -1,0 +1,19 @@
+package com.caesars.tracing
+
+import io.janstenpickle.trace4cats.model.{AttributeValue, CompletedSpan}
+
+package object testing {
+  def evalAttributes(xs: Map[String, AttributeValue]): Map[String, Any] =
+    xs.view.mapValues(_.value.value).toMap
+
+  implicit class AttributeOps(self: Map[String, AttributeValue]) {
+    val xs = evalAttributes(self)
+
+    def contains(key: String, value: Any): Boolean =
+      xs.get(key).contains(value)
+  }
+
+  implicit class CompletedSpanOps(val self: CompletedSpan) extends AnyVal {
+    def isRoot: Boolean = self.context.parent.isEmpty
+  }
+}

--- a/modules/zhttp/src/main/scala/com/caesars/tracing/TracedHttp.scala
+++ b/modules/zhttp/src/main/scala/com/caesars/tracing/TracedHttp.scala
@@ -1,0 +1,100 @@
+package com.caesars.tracing
+
+import io.janstenpickle.trace4cats.model.AttributeValue.{LongValue, StringValue}
+import io.janstenpickle.trace4cats.model.{AttributeValue, SpanKind, SpanStatus, TraceHeaders}
+import sttp.model.HeaderNames
+import zhttp.http.*
+import zio.*
+
+object TracedHttp {
+  def apply[R](
+      ztracer: ZTracer,
+      dropRequestWhen: Request => Boolean = _ => false,
+      dropHeadersWhen: String => Boolean = HeaderNames.isSensitive
+  )(app: HttpApp[R, Throwable]): HttpApp[R, Throwable] = {
+    import TracedHttpUtils.*
+
+    Http.fromOptionFunction {
+      case request if !dropRequestWhen(request) => createUndroppedSpannedResponse(request, ztracer, app, dropHeadersWhen)
+      case request                              => app(request)
+    }
+  }
+
+  def layer[R](
+      dropRequestWhen: Request => Boolean = _ => false,
+      dropHeadersWhen: String => Boolean = HeaderNames.isSensitive
+  )(app: HttpApp[R, Throwable]): URIO[Has[ZTracer], HttpApp[R, Throwable]] =
+    ZIO.service[ZTracer].map(apply[R](_, dropRequestWhen, dropHeadersWhen)(app))
+}
+
+object TracedHttpUtils {
+  def putHeadersInSpan(res: Response, span: ZSpan, dropHeadersWhen: String => Boolean = HeaderNames.isSensitive): UIO[Unit] = {
+    val headers: List[(String, AttributeValue)] =
+      "status.code" -> LongValue(res.status.asJava.code().toLong) ::
+        "status.message" -> StringValue(res.status.asJava.reasonPhrase()) ::
+        res.headers.toList
+          .filterNot { case (k, _) => dropHeadersWhen(k) }
+          .map { case (k, v) => k -> StringValue(v) }
+
+    span.putAll(headers*)
+  }
+
+  def createSpannedResponse[R](
+      request: Request,
+      span: ZSpan,
+      app: HttpApp[R, Throwable],
+      dropHeadersWhen: String => Boolean = HeaderNames.isSensitive
+  ): ZIO[R, Option[Throwable], Response] = {
+    app(request).tapBoth(
+      {
+        case None    => span.setStatus(SpanStatus.NotFound)
+        case Some(e) => span.setStatus(SpanStatus.Internal(e.toString))
+      },
+      { res =>
+        span.setStatus(toSpanStatus(res.status)) *> putHeadersInSpan(res, span, dropHeadersWhen)
+      }
+    )
+  }
+
+  def createUndroppedSpannedResponse[R](
+      request: Request,
+      ztracer: ZTracer,
+      app: HttpApp[R, Throwable],
+      dropHeadersWhen: String => Boolean = HeaderNames.isSensitive
+  ): ZIO[R, Option[Throwable], Response] = {
+    val method = request.method
+    val url = request.url
+    val headers = request.headers
+    val name = s"$method ${url.path}"
+    val traceHeaders =
+      TraceHeaders.of(
+        headers.toList.filterNot { case (k, _) => dropHeadersWhen(k) }*
+      )
+
+    ztracer.fromHeaders(traceHeaders, SpanKind.Server, name)(createSpannedResponse(request, _, app, dropHeadersWhen))
+    // All errors on this effects should be converted into responses by the Http app composition
+    // e.g. app.catchAll(e => Response)
+    // otherwise, the fiber dies  and tracing is moot
+  }
+
+  implicit class StatusOps(val self: Status) extends AnyVal {
+    def isSuccess: Boolean =
+      self.asJava.code() >= 200 && self.asJava.code() < 400
+  }
+
+  // TODO: incorporate response body into the span status
+  val toSpanStatus: Status => SpanStatus = {
+    case Status.BAD_REQUEST           => SpanStatus.Internal("Bad Request")
+    case Status.INTERNAL_SERVER_ERROR => SpanStatus.Internal("Internal Server Error")
+    case Status.UNAUTHORIZED          => SpanStatus.Unauthenticated
+    case Status.FORBIDDEN             => SpanStatus.PermissionDenied
+    case Status.NOT_FOUND             => SpanStatus.NotFound
+    case Status.TOO_MANY_REQUESTS     => SpanStatus.Unavailable
+    case Status.BAD_GATEWAY           => SpanStatus.Unavailable
+    case Status.SERVICE_UNAVAILABLE   => SpanStatus.Unavailable
+    case Status.GATEWAY_TIMEOUT       => SpanStatus.Unavailable
+    case status if status.isSuccess   => SpanStatus.Ok
+    case _                            => SpanStatus.Unknown
+  }
+
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,8 @@
+addDependencyTreePlugin
+
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.2")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.22")
+addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.16")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+ThisBuild / version := "0.1.0-SNAPSHOT"


### PR DESCRIPTION
Breaks the existing code into the following units:

- trace4cats-zio-extras-core: shared code
- trace4cats-zio-extras-sttp: extensions specific to sttp
- trace4cats-zio-extras-zhttp: extensions specific to zio-http
- trace4cats-zio-extras-testkit: comprehensive test suite + helpers for testing.

Do note that tightly coupled (i.e. - the server/client code is intertwined) nature of the existing test suite in PRU (which has been copied over to here), tests are defined in a separate module which also exports testing helpers.