### PR TITLE
Update newrelic-exporter to 0.13.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,8 +22,7 @@ lazy val root = (project in file("."))
 lazy val core = mkModule("core")
   .settings(
     libraryDependencies ++= List(
-      // TODO: replace Calvin's version with the canonical one once its released
-      "com.github.kaizen-solutions.trace4cats-newrelic" %% "trace4cats-newrelic-http-exporter" % "0.12.2",
+      "io.janstenpickle" %% "trace4cats-newrelic-http-exporter" % "0.13.1",
       "org.http4s" %% "http4s-async-http-client" % "0.23.10",
     )
   )
@@ -52,7 +51,7 @@ def zio(name: String) =
   "dev.zio" %% name % "1.0.14"
 
 def trace4cats(name: String) =
-  "io.janstenpickle" %% s"trace4cats-$name" % "0.12.0"
+  "io.janstenpickle" %% s"trace4cats-$name" % "0.13.1"
 
 def mkModule(id: String) = {
   val projectName = s"trace4cats-zio-extras-$id"


### PR DESCRIPTION
This PR updates the `trace4cats` deps to `0.13.1`, including `trace4cats-newrelic-http-exporter` which now has a release from the maintainers (we no longer need to depend on the custom release).