### PR TITLE
Bump zio to 1.0.15

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ lazy val testkit = mkModule("testkit")
   .dependsOn(core, sttp, zhttp)
 
 def zio(name: String) =
-  "dev.zio" %% name % "1.0.14"
+  "dev.zio" %% name % "1.0.15"
 
 def trace4cats(name: String) =
   "io.janstenpickle" %% s"trace4cats-$name" % "0.13.1"


### PR DESCRIPTION
I've had an issue going on for a few days that was really perplexing me. I was using a local version of #21 and was seeing spans fail inexplicably in New Relic, I just couldn't tell how or why, even adding a custom version of `trace4cats-newrelic` and the http-exporter to debug my interactions with their API.

The only thing that has caused them to start working again is #21 + the change in this PR bumping `zio` to `1.0.15`.